### PR TITLE
feat(server): advertise a configurable identity in the MCP handshake

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,8 @@ For **local (stdio)** use, the server is configured via environment variables. F
 | `BW_CLIENT` | SAP client (e.g. `001`) | yes |
 | `BW_LANGUAGE` | Language for object texts (e.g. `EN`, `DE`). Default: `DE` | no |
 | `BW_COOKIE_FILE` | Path to a browser-exported cookie file for SAML-/OAuth-fronted systems (e.g. BW Bridge). Netscape or `name=value` format. When set, `BW_USER` / `BW_PASSWORD` are optional. | no |
+| `BW_MCP_SERVER_NAME` | Server name advertised in the MCP `initialize` handshake. Default: `bw-modeling-mcp`. Give each instance a unique name when running several against different BW systems. | no |
+| `BW_MCP_SYSTEM_LABEL` | Free-text label of the connected BW system (e.g. `AP4 (BW production, read-only)`), put at the top of the MCP server instructions. Lets a model tell look-alike instances apart even in clients that show an opaque connector id instead of the server name. | no |
 
 **Cookie authentication (BW Bridge / SAP BTP):** For BW systems that sit behind a SAML or OAuth login (such as BW Bridge on the SAP BTP ABAP stack), Basic Auth is not available. Export the authenticated session cookies from your browser into a file and point `BW_COOKIE_FILE` at it. The login/session approach is analogous to [vibing-steampunk](https://github.com/oisee/vibing-steampunk) and [ARC-1](https://github.com/arc-mcp/arc-1). When the session expires, refresh the cookie file and restart the server.
 

--- a/docs/CLOUD-FOUNDRY.md
+++ b/docs/CLOUD-FOUNDRY.md
@@ -159,6 +159,8 @@ KBA **3361376259** (propagation over HTTPS), **3367280** (401 / credential popup
 | `BW_CC_LOCATION_ID` | Cloud Connector location id, when several are connected |
 | `BW_PUBLIC_URL` | advertised URL behind a reverse proxy |
 | `BW_ALLOWED_ORIGINS` | CORS allowlist for browser-based MCP clients |
+| `BW_MCP_SERVER_NAME` | server name in the MCP handshake (default `bw-modeling-mcp`); make it unique per instance |
+| `BW_MCP_SYSTEM_LABEL` | free-text system label (e.g. `AP4 (BW production, read-only)`) shown at the top of the server instructions |
 
 With `BW_PP_ENABLED=true` the server refuses to start if `BW_USER`, `BW_PASSWORD` or
 `BW_COOKIE_FILE` is also set: BW ties a session to whoever opened it, so one leftover

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
 import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 import { fileURLToPath } from 'node:url';
 import { realpathSync } from 'node:fs';
+import { createRequire } from 'node:module';
 
 import { createClientFromEnv, type BwClient } from './bw-client.js';
 import { currentClient } from './request-context.js';
@@ -5669,6 +5670,32 @@ async function handleToolCall(
 
 // ── Server ────────────────────────────────────────────────────────────────────
 
+// The package version doubles as the advertised server version; a hardcoded copy here
+// drifted to 0.1.0 while the package was at 1.4.0.
+const { version: VERSION } = createRequire(import.meta.url)('../package.json') as { version: string };
+
+/**
+ * Sent in the MCP initialize response. Clients that defer tool loading use it to decide
+ * whether this server's tools are worth fetching at all, so the domain is named up front.
+ * BW_MCP_SYSTEM_LABEL exists because several instances of this server typically point at
+ * different BW systems (dev/QA/prod), and some clients show an opaque connector id instead
+ * of the advertised server name — the label is then the only thing that tells the model
+ * which system it is talking to, without a probing tool call.
+ */
+function buildInstructions(): string {
+  const label = process.env.BW_MCP_SYSTEM_LABEL;
+  return [
+    ...(label ? [`Connected SAP BW system: ${label}.`, ''] : []),
+    'SAP BW modeling over the BW backend APIs: aDSOs, InfoObjects, CompositeProviders,',
+    'transformations, DTPs, DataSources, InfoSources, source systems, process chains and',
+    'their runs, requests/loads, queries and query data, planning artifacts, and transports.',
+    'Reach for it for any question about BW metadata, data flows, load monitoring, or query',
+    'definitions on this system.',
+    '',
+    'One BW system per instance: there is no system selector, by design.',
+  ].join('\n');
+}
+
 /**
  * Build an MCP server with every tool registered.
  *
@@ -5678,8 +5705,10 @@ async function handleToolCall(
  */
 export function createServer(): Server {
   const server = new Server(
-    { name: 'bw-modeling-mcp', version: '0.1.0' },
-    { capabilities: { tools: {} } }
+    // BW_MCP_SERVER_NAME lets each instance advertise which system it fronts (e.g.
+    // "bw-mcp-prod"), so clients that key on the handshake name can tell them apart.
+    { name: process.env.BW_MCP_SERVER_NAME || 'bw-modeling-mcp', version: VERSION },
+    { capabilities: { tools: {} }, instructions: buildInstructions() }
   );
 
   server.setRequestHandler(ListToolsRequestSchema, async (_request, extra) => ({

--- a/tests/server-identity.test.mjs
+++ b/tests/server-identity.test.mjs
@@ -1,0 +1,61 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+/** Start the stdio server with extra env and return the initialize result. */
+function initialize(extraEnv = {}) {
+  return new Promise((resolve, reject) => {
+    const srv = spawn('node', ['dist/stdio.js'], {
+      env: { ...process.env, BW_URL: 'http://unused.invalid:8000', BW_USER: 'x', BW_PASSWORD: 'x', ...extraEnv },
+      stdio: ['pipe', 'pipe', 'ignore'],
+    });
+    const send = (m) => srv.stdin.write(JSON.stringify(m) + '\n');
+    send({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 't', version: '1' } } });
+    let buf = '';
+    const timer = setTimeout(() => { srv.kill(); reject(new Error('timeout')); }, 20000);
+    srv.stdout.on('data', (d) => {
+      buf += d;
+      const lines = buf.split('\n');
+      buf = lines.pop();
+      for (const l of lines) {
+        if (!l.trim()) continue;
+        const msg = JSON.parse(l);
+        if (msg.id === 1) {
+          clearTimeout(timer);
+          srv.kill();
+          resolve(msg.result);
+        }
+      }
+    });
+  });
+}
+
+test('the default identity is unchanged, and the version is the package version', async () => {
+  const result = await initialize();
+  assert.equal(result.serverInfo.name, 'bw-modeling-mcp');
+  // The advertised version was a hardcoded copy and had drifted to 0.1.0; it must
+  // follow the package version from now on.
+  const { version } = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+  assert.equal(result.serverInfo.version, version);
+});
+
+test('instructions name the domain so deferring clients can decide to load the tools', async () => {
+  const result = await initialize();
+  assert.match(result.instructions, /SAP BW modeling/);
+  assert.match(result.instructions, /One BW system per instance/);
+});
+
+test('BW_MCP_SERVER_NAME renames the instance in the handshake', async () => {
+  const result = await initialize({ BW_MCP_SERVER_NAME: 'bw-mcp-prod' });
+  assert.equal(result.serverInfo.name, 'bw-mcp-prod');
+});
+
+test('BW_MCP_SYSTEM_LABEL puts the connected system into the instructions', async () => {
+  const label = 'AP4 (BW production, read-only)';
+  const result = await initialize({ BW_MCP_SYSTEM_LABEL: label });
+  // First line, so a model scanning several look-alike BW servers sees the difference
+  // immediately instead of probing each with a tool call.
+  assert.ok(result.instructions.startsWith(`Connected SAP BW system: ${label}.`));
+  assert.match(result.instructions, /SAP BW modeling/);
+});


### PR DESCRIPTION
Fixes #26. Three changes, all in the `initialize` response:

- **`BW_MCP_SERVER_NAME`** names the instance in `serverInfo` (default unchanged: `bw-modeling-mcp`).
- **The server now sends `instructions`**: the domain first, so clients that defer tool loading can decide whether these tools are worth fetching; with **`BW_MCP_SYSTEM_LABEL`** set, the connected system becomes the first line — e.g. `AP4 (BW production, read-only)` — which identifies the instance even when the client shows an opaque connector id instead of the server name.
- **`serverInfo.version` follows `package.json`** instead of a hardcoded copy that had drifted to 0.1.0.

Both env vars are optional; without them the handshake is byte-identical except for the version and the new instructions. Covered by four end-to-end tests speaking JSON-RPC against `dist/stdio.js`; docs updated in README and docs/CLOUD-FOUNDRY.md.


